### PR TITLE
add method `.clone-normalized`, and tests

### DIFF
--- a/lib/Math/Angle.rakumod
+++ b/lib/Math/Angle.rakumod
@@ -290,6 +290,15 @@ method normalize(:$range = SYMMETRIC) {
     $!angle = $newangle;
 }
 
+#| Return a normalized clone, leaving the original unmodified.
+method clone-normalized(:$range = SYMMETRIC) {
+    with self.clone {
+        .normalize(:$range);
+        return $_
+    }
+}
+
+
 method Numeric() { $!angle }
 
 #|««

--- a/t/01-basic.rakutest
+++ b/t/01-basic.rakutest
@@ -1,7 +1,7 @@
 use Test;
 use Math::Angle;
 
-plan 20;
+plan 22;
 
 my $a1 = Math::Angle.new(:45deg);
 my $a2 = Math::Angle.new(:rad(0.5));
@@ -29,6 +29,15 @@ is-approx Math::Angle::atan2(2, 1).rad, 1.1071487177, 'atan2';
 
 is-approx Math::Angle.new(rad => -π/2).normalize(range => POSITIVE), 3×π/2, 'positive normalization';
 is-approx Math::Angle.new(rad => 7×π/2).normalize, -π/2, 'symmetric normalization';
+
+with Math::Angle.new(:deg(126188.82366063185)) {
+    is-approx $_.clone-normalized(:range(SYMMETRIC)).deg,
+              -171.17633936815307,
+              'symmetrically normalized clone';
+    is-approx $_.clone-normalized(:range(POSITIVE)).deg,
+              188.82366063184693,
+              'positively normalized clone';
+}
 
 is-approx 45°.deg, 45, 'degree sign postfix operatore';
 


### PR DESCRIPTION
Adds:

1. `method clone-normalized` (to lib/Math/Angle.rakumod)
2. two tests (to t/01-basic.rakutest)

The new method returns a normalized clone of the Math::Angle object, without modifying the original object.

(The existing normalize method modifies the object in place and returns the raw normalized angle in radians.)